### PR TITLE
Fix masked setting.

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -16,7 +16,6 @@
       max,
       allowBlank,
       minimumNumberOfCharacters,
-      masked,
       debug,
     }"
     class="v-money3" />
@@ -49,7 +48,7 @@ export default defineComponent({
     },
     masked: {
       type: Boolean,
-      default: true
+      default: false
     },
     precision: {
       type: Number,
@@ -102,14 +101,14 @@ export default defineComponent({
   setup(props, { emit, attrs }) {
 
     const data = reactive({
-      formattedValue: props.masked ? format(props.modelValue, props, 'setup') : props.modelValue,
+      formattedValue: format(props.modelValue, props, 'setup'),
     });
 
     watch(
         () => props.modelValue, (val) => {
-          const value = props.masked ? format(val, props, 'watch') : val;
-          if (value !== data.formattedValue) {
-            data.formattedValue = value;
+          const formatted = format(val, props, 'watch');
+          if (formatted !== data.formattedValue) {
+            data.formattedValue = formatted;
           }
         }
     )

--- a/src/directive.js
+++ b/src/directive.js
@@ -9,7 +9,7 @@ const setValue = (el, opt, caller) => {
     return;
   }
   let positionFromEnd = el.value.length - el.selectionEnd
-  el.value = opt.masked ? format(el.value, opt, caller) : unformat(el.value, opt, caller)
+  el.value = format(el.value, opt, caller)
   lastKnownValue = el.value;
   positionFromEnd = Math.max(positionFromEnd, opt.suffix.length) // right
   positionFromEnd = el.value.length - positionFromEnd

--- a/tests/component.test.js
+++ b/tests/component.test.js
@@ -93,13 +93,13 @@ test('Test precision attribute', async () => {
 
     for (let precision = 0; precision < 10; precision++) {
 
-        const input = mountComponent({ precision, masked: false }).find('input');
+        const input = mountComponent({ precision, thousands: '' }).find('input');
 
-        const number = 1234567891234 / (!precision ? 1 : Math.pow(10, precision))
+        const number = 1234567891234
 
         await input.setValue(number)
 
-        const toBe = parseFloat(number).toFixed(precision)
+        const toBe = (number / Math.pow(10, precision)).toFixed(precision)
 
         expect(input.element.value).toBe(toBe)
     }
@@ -257,14 +257,17 @@ test('Test if US format works correctly', async () => {
 
 test('Test if non masked values are correctly translated', async () => {
 
-    let input = mountComponent({
+    let component = mountComponent({
         decimal: '.',
         thousands: ',',
         precision: 2,
         masked: false,
-    }).find('input');
+    });
+    let input = component.find('input');
 
     await input.setValue('5971513.15');
 
-    expect(input.element.value).toBe('5971513.15');
+    let updates = component.emitted()['update:model-value'];
+    expect(updates[updates.length - 1][0]).toBe('5971513.15');
+    expect(input.element.value).toBe('5,971,513.15');
 })


### PR DESCRIPTION
The `masked` setting was broken by 624ad7bc76ab93e1f4a44f9fddf8b21792a19480.

My understanding is that the `masked` setting has no effect on the directive and the input value will always be masked. On the component `masked: true` should work the same as the directive, and `masked: false` should show the mask on the input but the `v-model` binding should _not_ have the mask.