### PR TITLE
Package lock bump and test fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "v-money3",
-  "version": "3.14.2",
+  "version": "3.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.14.2",
+      "version": "3.15.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.14.5",

--- a/tests/puppeteer.test.js
+++ b/tests/puppeteer.test.js
@@ -17,7 +17,7 @@ describe('Puppeteer Tests', () => {
     const data = ['R$ ', '$', '€', '₿', '1\\', '2\\'];
 
     for (const prefix of data) {
-      await page.goto(`${serverUrl}?prefix=${prefix.replaceAll(' ', '+')}`);
+      await page.goto(`${serverUrl}?prefix=${prefix.replace(/\s/g, '+')}`);
 
       await page.focus('#component');
       await page.type('#component', '12345');
@@ -31,8 +31,8 @@ describe('Puppeteer Tests', () => {
 
     for (const suffix of data) {
       const treated = suffix
-        .replaceAll('%', '%25')
-        .replaceAll('#', '%23');
+        .replace(/%/g, '%25')
+        .replace(/#/g, '%23');
 
       await page.goto(`${serverUrl}?suffix=${treated}`);
 
@@ -47,7 +47,7 @@ describe('Puppeteer Tests', () => {
     const data = [',', '.', '|', '#', ';'];
 
     for (const thousands of data) {
-      const treated = thousands.replaceAll('#', '%23');
+      const treated = thousands.replace(/#/g, '%23');
 
       await page.goto(`${serverUrl}?thousands=${treated}`);
 
@@ -63,8 +63,8 @@ describe('Puppeteer Tests', () => {
 
     for (const decimal of data) {
       const treated = decimal
-        .replaceAll('#', '%23')
-        .replaceAll(',', '%2C');
+        .replace(/#/g, '%23')
+        .replace(/#,/g, '%2C');
 
       await page.goto(`${serverUrl}?decimal=${treated}`);
 


### PR DESCRIPTION
Running npm install updated the package-lock.json

Replaced the `.replaceAll` calls in `puppeteer.test.js` to `.replace` calls.
I don't know why, but Node kinda sucks sometimes and I can't find a stable node version that implements `.replaceAll`.
This seems to be a common issue: https://stackoverflow.com/questions/65295584/jest-typeerror-replaceall-is-not-a-function

So I took the shortest path and replaced to `.replace` with regex in order to avoid future compatibility issues with new contributors ~like me~