### PR TITLE
Possibility to start with negative symbol

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -29,6 +29,8 @@ export default function format(
     }
   } else if (opt.modelModifiers && opt.modelModifiers.number && isValidInteger(input)) {
     input = Number(input).toFixed(fixed(opt.precision));
+  } else if (!opt.disableNegative && input == '-') {
+    return input;
   }
 
   debug(opt, 'utils format() - input2', input);


### PR DESCRIPTION
Most of the time when people enter a negative number, they start with the negative symbol. It was supported, but only once there was already a number entered.