### PR TITLE
Update vite.config.js

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ const path = require('path');
 export default defineConfig({
   plugins: [vue()],
   build: {
-    target: 'es2020',
+    target: 'esnext',
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),
       name: 'v-money3',


### PR DESCRIPTION
possible solution for error with vite.

Problem:

`✘ [ERROR] Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)

    node_modules/.pnpm/v-money3@3.21.0_vue@3.2.39/node_modules/v-money3/dist/v-money3.es.js:137:34:
      137 │     __publicField(this, "number", 0n);
          ╵                                   ~~

✘ [ERROR] Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)

    node_modules/.pnpm/v-money3@3.21.0_vue@3.2.39/node_modules/v-money3/dist/v-money3.es.js:223:41:
      223 │       thatNum = thatNumber.getNumber() * 10n ** BigInt(diff);
          ╵                                          ~~~

✘ [ERROR] Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)

    node_modules/.pnpm/v-money3@3.21.0_vue@3.2.39/node_modules/v-money3/dist/v-money3.es.js:225:35:
      225 │       thisNum = this.getNumber() * 10n ** BigInt(diff * -1);`
