### PR TITLE
Fix typescript error TS7016: Could not find a declaration file for module 'v-money3'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,14 @@
   "module": "./dist/v-money3.mjs",
   "exports": {
     ".": {
-      "import": "./dist/v-money3.mjs",
-      "require": "./dist/v-money3.umd.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/v-money3.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/v-money3.umd.js"
+      }
     }
   },
   "typings": "./dist/index.d.ts",


### PR DESCRIPTION
I got this error when installing v-money3 on a new Vue project created with `npm create vue@latest`.

```
error TS7016: Could not find a declaration file for module 'v-money3'. '{project_path}/node_modules/v-money3/dist/v-money3.mjs' implicitly has an 'any' type.
  There are types at '{project_path}/node_modules/v-money3/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'v-money3' library may need to update its package.json or typings.
```
![2023-08-04-0830-Code_FKNtUtCjIR](https://github.com/jonathanpmartins/v-money3/assets/13524958/a972126d-50fa-4bb8-bf1c-252e19334e76)

I applied the [solution provided by cmdruid here](https://github.com/microsoft/TypeScript/issues/52363#issuecomment-1659179354).

When I applied this fix on `node_modules/v-money3/package.json` and re-run `npm run type-check`, the error is gone.