### PR TITLE
Adding Lazy option and fix directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.devcontainer/
 node_modules/
 dist/
 coverage/

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -134,3 +134,17 @@ export function event(name: string): Event {
 export function debug({ debug = false }: VMoneyOptions | ExtractPropTypes<any>, ...args: any): void {
   if (debug) console.log(...args);
 }
+
+export const getInputElement = (el: HTMLInputElement): HTMLInputElement => {
+  // v-money3 used on a component that's not a input
+  if (el.tagName.toLocaleUpperCase() !== "INPUT") {
+    const els = el.getElementsByTagName("input");
+    if (els.length !== 1) {
+      // throw new Error("v-money3 requires 1 input, found " + els.length)
+    } else {
+      // eslint-disable-next-line prefer-destructuring
+      return els[0];
+    }
+  }
+  return el;
+};  

--- a/src/options.ts
+++ b/src/options.ts
@@ -16,6 +16,7 @@ export interface VMoneyOptions {
   modelModifiers: any;
   shouldRound: boolean;
   focusOnRight: boolean;
+  lazy: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
@@ -39,4 +40,5 @@ export default {
   },
   shouldRound: true,
   focusOnRight: false,
+  lazy: true,
 } as VMoneyOptions;


### PR DESCRIPTION
closes #74 

- Adding the search for the closest input element to the "updated" directive
- Add 'lazy' option to maintain compatibility with UI frameworks (example: Naive UI, ElementUI etc..)

NaiveUI Working Example
```html
<n-input
    v-model:value="price"
    v-money="{
      decimal: ',',
      thousands: '.',
      precision: 2,
      masked: false,
      debug: true,
      lazy: false
    }"
/>
```