### PR TITLE
feat: setMaxIfBigger option to disable max auto-clamp (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Feature
+- New property `setMaxIfBigger` (default `true`) gives developers control over the auto-clamp-to-`max` behavior. When set to `false`, a keystroke that would push the value past `max` is rejected and the display reverts to the last valid value — instead of jumping to the over-max digit sequence and snapping down to `max`. Applied to both `format()` / `unformat()` (which skip the max clamp under the flag) and the directive (which tracks the last in-bounds display and restores it on overflow). Closes issue [#96](https://github.com/jonathanpmartins/v-money3/issues/96).
+
 ## [3.25.1] / 2026-05-16
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ app.directive('money3', Money3Directive)
           disabled: false,
           min: null,
           max: null,
+          setMaxIfBigger: true,
           allowBlank: false,
           treatZeroAsBlank: true,
           minimumNumberOfCharacters: 0,
@@ -178,6 +179,7 @@ To ensure proper functionality, you must use `v-model.lazy` for binding.
           disabled: false,
           min: null,
           max: null,
+          setMaxIfBigger: true,
           allowBlank: false,
           treatZeroAsBlank: true,
           minimumNumberOfCharacters: 0,
@@ -219,6 +221,7 @@ If you directly bind it, you're perfectly fine as well:
 | disabled                     | false    | Boolean  | false   | Disable the inner input tag                                |
 | min                          | false    | Number   | null    | The min value allowed                                      |
 | max                          | false    | Number   | null    | The max value allowed                                      |
+| set-max-if-bigger            | false    | Boolean  | true    | When `true` (default), values above `max` are clamped down to `max`. Set to `false` to reject keystrokes that would exceed `max` — the input keeps its last valid value instead of jumping to the ceiling. No effect when `max` is `null` |
 | allow-blank                  | false    | Boolean  | false   | If the field can start blank and be cleared out by user    |
 | treat-zero-as-blank          | false    | Boolean  | true    | When `allow-blank` is true, controls whether zero is rendered as blank. Set to `false` to distinguish zero from blank (e.g. show `0.00` and only blank on empty input). Has no effect when `allow-blank` is false |
 | minimum-number-of-characters | false    | Number   | 0       | The minimum number of characters that the mask should show |
@@ -269,6 +272,7 @@ const config = {
     disabled: false,
     min: null,
     max: null,
+    setMaxIfBigger: true,
     allowBlank: false,
     treatZeroAsBlank: true,
     minimumNumberOfCharacters: 0,

--- a/src/component.vue
+++ b/src/component.vue
@@ -11,6 +11,7 @@
       disableNegative: props.disableNegative,
       min: props.min,
       max: props.max,
+      setMaxIfBigger: props.setMaxIfBigger,
       allowBlank: props.allowBlank,
       treatZeroAsBlank: props.treatZeroAsBlank,
       minimumNumberOfCharacters: props.minimumNumberOfCharacters,
@@ -134,6 +135,10 @@ const props = defineProps({
     type: [Number, String],
     default: () => defaults.min,
   },
+  setMaxIfBigger: {
+    type: Boolean,
+    default: () => defaults.setMaxIfBigger,
+  },
   allowBlank: {
     type: Boolean,
     default: () => defaults.allowBlank,
@@ -244,6 +249,7 @@ watch(
     props.suffix,
     props.min,
     props.max,
+    props.setMaxIfBigger,
     props.allowBlank,
     props.treatZeroAsBlank,
     props.minimumNumberOfCharacters,

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -11,15 +11,20 @@ import {
 import format from './format';
 import unformat from './unformat';
 import defaults, { VMoneyOptions } from './options';
+import BigNumber from './BigNumber';
 
 // this option is used for ALL directive instances
 // let opt: VMoneyOptions = defaults;
 
 const FORMAT_AFFECTING_KEYS = [
   'precision', 'decimal', 'thousands', 'prefix', 'suffix',
-  'min', 'max', 'allowBlank', 'treatZeroAsBlank',
+  'min', 'max', 'setMaxIfBigger', 'allowBlank', 'treatZeroAsBlank',
   'minimumNumberOfCharacters', 'shouldRound', 'modelModifiers',
 ] as const;
+
+const LAST_VALID_KEY = '__v_money3_last_valid__';
+
+type InputWithLastValid = HTMLInputElement & { [LAST_VALID_KEY]?: string };
 
 const setValue = (
   el: HTMLInputElement,
@@ -37,9 +42,31 @@ const setValue = (
 
   const formatted = format(el.value, opt, caller);
 
-  if (formatted === el.value) return; // prevent unnecessary updates
+  // setMaxIfBigger=false: format() returns the un-clamped value. Reject the
+  // keystroke that pushed the numeric value past max by restoring the last
+  // valid display so the input "stays at" the previous in-bounds state.
+  if (
+    opt.setMaxIfBigger === false
+    && opt.max !== null && opt.max !== undefined && opt.max !== ''
+  ) {
+    const unformatted = unformat(formatted, opt, 'directive setValue overflow check');
+    const bn = new BigNumber(String(unformatted));
+    if (bn.biggerThan(opt.max)) {
+      const lastValid = (el as InputWithLastValid)[LAST_VALID_KEY];
+      if (typeof lastValid === 'string' && lastValid !== el.value) {
+        el.value = lastValid;
+      }
+      return;
+    }
+  }
+
+  if (formatted === el.value) {
+    (el as InputWithLastValid)[LAST_VALID_KEY] = formatted;
+    return; // prevent unnecessary updates
+  }
 
   el.value = formatted;
+  (el as InputWithLastValid)[LAST_VALID_KEY] = formatted;
 
   positionFromEnd = Math.max(positionFromEnd, opt.suffix.length); // right
   positionFromEnd = el.value.length - positionFromEnd;

--- a/src/format.ts
+++ b/src/format.ts
@@ -70,7 +70,8 @@ export default function format(
   debug(opt, 'utils format() - bigNumber1', bigNumber.toString());
 
   // min and max must be a valid float or integer
-  if (opt.max !== null && opt.max !== undefined && opt.max !== '') {
+  if (opt.setMaxIfBigger !== false
+    && opt.max !== null && opt.max !== undefined && opt.max !== '') {
     if (bigNumber.biggerThan(opt.max)) {
       bigNumber.setNumber(opt.max);
     }

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,6 +10,7 @@ export interface VMoneyOptions {
   disabled: boolean;
   min: number | string | null;
   max: number | string | null;
+  setMaxIfBigger: boolean;
   allowBlank: boolean;
   treatZeroAsBlank: boolean;
   minimumNumberOfCharacters: number;
@@ -34,6 +35,7 @@ export default {
   disabled: false,
   min: null,
   max: null,
+  setMaxIfBigger: true,
   allowBlank: false,
   treatZeroAsBlank: true,
   minimumNumberOfCharacters: 0,

--- a/src/unformat.ts
+++ b/src/unformat.ts
@@ -33,7 +33,8 @@ export default function unformat(
   debug(opt, 'utils unformat() - bigNumber1', numbers.toString());
 
   /// min and max must be a valid float or integer
-  if (opt.max !== null && opt.max !== undefined && opt.max !== '') {
+  if (opt.setMaxIfBigger !== false
+    && opt.max !== null && opt.max !== undefined && opt.max !== '') {
     if (bigNumber.biggerThan(opt.max)) {
       bigNumber.setNumber(opt.max);
     }

--- a/tests/component/App.vue
+++ b/tests/component/App.vue
@@ -63,6 +63,7 @@ if (payload && payload.length) {
     disabled: !!get('disabled', false),
     min: get('min', `${Number.MIN_SAFE_INTEGER}`),
     max: get('max', `${Number.MAX_SAFE_INTEGER}`),
+    setMaxIfBigger: get('setMaxIfBigger') !== 'false',
     allowBlank: !!get('allowBlank', false),
     minimumNumberOfCharacters: get('minimumNumberOfCharacters', 0),
     modelModifiers: {

--- a/tests/env/jsdom/component.test.ts
+++ b/tests/env/jsdom/component.test.ts
@@ -957,3 +957,39 @@ test('component setup path tolerates precision > 100 (no RangeError)', async () 
     shouldRound: true,
   })).not.toThrow();
 });
+
+test('#96 — setMaxIfBigger=false keeps last valid display when typing past max', async () => {
+  // Issue scenario: max=100, precision=0. User types "99" (valid), then a
+  // third digit '3' making it 993. Default behavior auto-clamps to 100. With
+  // setMaxIfBigger=false the input should retain the previous valid value
+  // ("99") rather than snap to the ceiling.
+  const component = mountComponent({
+    max: 100,
+    precision: 0,
+    setMaxIfBigger: false,
+  });
+  const input = component.find('input');
+
+  await input.setValue('99');
+  expect(input.element.value).toBe('99');
+
+  await input.setValue('993');
+
+  expect(input.element.value).toBe('99');
+});
+
+test('#96 — setMaxIfBigger default (true) still clamps to max', async () => {
+  // Regression guard: omitting the flag preserves the historical clamp.
+  const component = mountComponent({
+    max: 100,
+    precision: 0,
+  });
+  const input = component.find('input');
+
+  await input.setValue('99');
+  expect(input.element.value).toBe('99');
+
+  await input.setValue('993');
+
+  expect(input.element.value).toBe('100');
+});

--- a/tests/env/jsdom/format.test.ts
+++ b/tests/env/jsdom/format.test.ts
@@ -116,6 +116,22 @@ test('format should clamp when min or max is zero (number or string)', () => {
   expect(format(-5, { ...defaults, min: '0', max: '10' })).toBe('0.00');
 });
 
+test('#96 — setMaxIfBigger=false disables max clamping in format()', () => {
+  // default (setMaxIfBigger=true, implicit) clamps to max
+  expect(format(11, { ...defaults, max: 10 })).toBe('10.00');
+
+  // setMaxIfBigger=false: value over max is preserved, not snapped to max
+  expect(format(11, { ...defaults, max: 10, setMaxIfBigger: false })).toBe('11.00');
+  expect(format(99.99, { ...defaults, max: 10, setMaxIfBigger: false })).toBe('99.99');
+  expect(format('990.03', { ...defaults, max: 100, setMaxIfBigger: false, precision: 0 })).toBe('990');
+
+  // min still clamps even when setMaxIfBigger is false (flag scoped to max)
+  expect(format(5, { ...defaults, min: 10, max: 100, setMaxIfBigger: false })).toBe('10.00');
+
+  // values within bounds unaffected
+  expect(format(5, { ...defaults, max: 10, setMaxIfBigger: false })).toBe('5.00');
+});
+
 test('format should clamp precision via fixed() at every call site', () => {
   // bug: numbersToCurrency() inside format() is called with the raw
   // opt.precision, while every other site (input.toFixed, BigNumber.toFixed,

--- a/tests/env/jsdom/unformat.test.ts
+++ b/tests/env/jsdom/unformat.test.ts
@@ -18,6 +18,21 @@ test('unformat min max options should be respected', () => {
   expect(unformat('12,345.67', { ...defaults, debug: true }, 'unit test')).toBe('12345.67');
 });
 
+test('#96 — setMaxIfBigger=false disables max clamping in unformat()', () => {
+  // default behavior clamps
+  expect(unformat('11.00', { ...defaults, max: 10 })).toBe('10.00');
+
+  // setMaxIfBigger=false preserves over-max value
+  expect(unformat('11.00', { ...defaults, max: 10, setMaxIfBigger: false })).toBe('11.00');
+  expect(unformat('123.45', { ...defaults, max: 100, setMaxIfBigger: false })).toBe('123.45');
+
+  // min still applies
+  expect(unformat('5.00', { ...defaults, min: 10, max: 100, setMaxIfBigger: false })).toBe('10.00');
+
+  // within bounds unaffected
+  expect(unformat('9.00', { ...defaults, max: 10, setMaxIfBigger: false })).toBe('9.00');
+});
+
 test('unformat number should strip the string', () => {
   expect(unformat('R$ 1.123,45/100', {
     ...defaults,

--- a/tests/env/puppeteer/e2e.test.ts
+++ b/tests/env/puppeteer/e2e.test.ts
@@ -255,6 +255,27 @@ describe('Puppeteer Component Tests', () => {
     expect(await getValue()).toBe('10.00');
   });
 
+  it(`#96 — setMaxIfBigger=false stops keystrokes that exceed max ${target}`, async () => {
+    // Issue scenario from #96: max=100, precision=0. Typing "99" is valid;
+    // the next digit would push the value past max. Default clamps to 100;
+    // with setMaxIfBigger=false the display should retain "99" instead.
+    await page.goto(`${serverUrlWithTarget}&max=100&precision=0&setMaxIfBigger=false`);
+
+    await page.focus(target);
+    await page.type(target, '99');
+    expect(await getValue()).toBe('99');
+
+    await page.type(target, '3');
+    expect(await getValue()).toBe('99');
+
+    // Regression: default (omit flag) still clamps.
+    await page.goto(`${serverUrlWithTarget}&max=100&precision=0`);
+
+    await page.focus(target);
+    await page.type(target, '993');
+    expect(await getValue()).toBe('100');
+  });
+
   it(`Test allow-blank attribute ${target}`, async () => {
     await page.goto(`${serverUrlWithTarget}&allowBlank=true`);
 


### PR DESCRIPTION
## Summary

- New optional prop `setMaxIfBigger` (default `true` — current behavior). When set to `false`, typing past `max` no longer auto-clamps the value to `max`; the directive restores the last in-bounds display so the input "stays at" the previous valid value.
- Two-layer implementation:
  - `format()` / `unformat()` skip the max-clamp branch when the flag is false (`min` clamping and `disableNegative` re-clamping unaffected).
  - `directive.ts` stashes the last in-bounds display per element on `setValue()` and reverts on overflow, short-circuiting before the `change` event so the parent v-model stays put.
- `component.vue` declares the prop, threads it into the directive binding, and adds it to the opts watcher; `FORMAT_AFFECTING_KEYS` updated so the bare-directive corruption guard recognizes the flag.

Closes #96.

## Test plan

- [x] Unit: `tests/env/jsdom/format.test.ts` — flag off preserves over-max value; default clamps; `min` still applies; in-bounds unaffected.
- [x] Unit: `tests/env/jsdom/unformat.test.ts` — mirror coverage for `unformat()`.
- [x] Component: `tests/env/jsdom/component.test.ts` — typing past `max=100` (precision 0) with flag off keeps display at `"99"`; regression guard verifies default still clamps to `"100"`.
- [x] E2E (puppeteer): `tests/env/puppeteer/e2e.test.ts` — real-browser reproduction of issue scenario; harness wiring added to `tests/component/App.vue` to drive the flag via query param.
- [x] Full suite: 9 jest projects / 150 tests pass.
- [x] `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)